### PR TITLE
37 - Fixes ngx-translate-testing Test Cases

### DIFF
--- a/projects/testing/src/test.ts
+++ b/projects/testing/src/test.ts
@@ -1,6 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'core-js/es7/reflect';
+import 'core-js/es/reflect';
 import 'zone.js/dist/zone';
 import 'zone.js/dist/zone-testing';
 import { getTestBed } from '@angular/core/testing';
@@ -12,10 +12,7 @@ import {
 declare const require: any;
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
-);
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.


### PR DESCRIPTION
Resolves an issue where the test cases for ngx-translate-testing would
not run successfully due to a change in the path for the "reflect"
library within the core-js project.