### PR TITLE
Add translate parser support

### DIFF
--- a/projects/testing/README.md
+++ b/projects/testing/README.md
@@ -116,6 +116,16 @@ TranslateTestingModule
   .withCompiler(new TranslateMessageFormatCompiler())
 ```
 
+#### Custom Parser
+
+The default parser used in the `TranslateTestingModule` it is an instance of `TranslateDefaultParser`. If your translations use a custom parser, you can specify the parser with the `withParser()` instance method.
+
+```ts
+TranslateTestingModule
+  .withTranslations("en", require("../../assets/i18n/en.json"))
+  .withParser(new CustomTranslateDefaultParser())
+```
+
 ## License
 Licensed under MIT
 

--- a/projects/testing/src/lib/testing.module.spec.ts
+++ b/projects/testing/src/lib/testing.module.spec.ts
@@ -308,5 +308,23 @@ describe('TranslateTestingModule', () => {
         expect(translateService.compiler).toEqual(translateCompiler);
       });
     });
+
+    describe('withParser()', () => {
+      it('should be a function', () => {
+        expect(translateModule.withParser).toBeTruthy();
+        expect(typeof translateModule.withParser).toEqual('function');
+      });
+
+      it('should override the parser for the provided TranslateService instance', () => {
+        const translateParser = jasmine.createSpyObj('TranslateParser', ['getValue']);
+        translateModule.withParser(translateParser);
+
+        expect(translateModule.providers).toBeTruthy();
+        expect(translateModule.providers.length).toBe(1);
+
+        const translateService = translateModule.providers[0].useValue;
+        expect(translateService.parser).toEqual(translateParser);
+      });
+    });
   });
 });

--- a/projects/testing/src/lib/testing.module.ts
+++ b/projects/testing/src/lib/testing.module.ts
@@ -30,6 +30,8 @@ export class TranslateTestingModule implements ModuleWithProviders<TranslateTest
 
   private _compiler: TranslateCompiler;
 
+  private _parser: TranslateDefaultParser;
+
   /**
    * Creates a new instance of the {TranslateTestingModule} with translations for the specified language.
    *
@@ -94,7 +96,7 @@ export class TranslateTestingModule implements ModuleWithProviders<TranslateTest
       null,
       new TestTranslateLoader(this._translations),
       this._compiler || new TranslateFakeCompiler(),
-      new TranslateDefaultParser(),
+      this._parser || new TranslateDefaultParser(),
       new FakeMissingTranslationHandler(),
       true,
       true,
@@ -183,6 +185,24 @@ export class TranslateTestingModule implements ModuleWithProviders<TranslateTest
    */
   public withCompiler(compiler: TranslateCompiler): TranslateTestingModule {
     this._compiler = compiler;
+    return this;
+  }
+
+  /**
+   * Updates the {TranslateTestingModule} to provide a {TranslateService} that will
+   * use the provided {TranslateParser} to parse the test translations.
+   *
+   * @example
+   *
+   * TranslateTestingModule.withTranslations('en', {key: 'content'})
+   *   .withParser(new CustomTranslateDefaultParser());
+   *
+   * @param parser the parser to use to parse the test translations.
+   * @returns the instance that can be used to chain additional configuration.
+   * @memberof TranslateTestingModule
+   */
+  public withParser(parser: TranslateDefaultParser): TranslateTestingModule {
+    this._parser = parser;
     return this;
   }
 


### PR DESCRIPTION
## Add translate parser support

Added the new method `withParser` for supporting a custom `TranslateDefaultParser` for `TranslateService`.

![Screen Shot 2023-04-11 at 14 27 13](https://user-images.githubusercontent.com/5215241/231242091-2c91dda5-e620-480c-a388-06476db4f797.png)
